### PR TITLE
Crlf fix

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,6 @@ db/schema.rb linguist-generated
 
 # Mark any vendored files as having been vendored.
 vendor/* linguist-vendored
+
+# CRLF fix for ruby files
+*.rb text eol=lf


### PR DESCRIPTION
What I've done:
- Added `*.rb text eol=lf` to `.gitattributes` to ensure ruby files always end in LF.

What else needs to be done (after you get this commit onto your local repo):
1. Save everything to git (add/commit)
2. `git rm -rf --cached .`
3. `git reset --hard HEAD`
4. To see if any changes were made: `git status`
5. See source for additional notes.

Additional Notes:
- Hopefully this works.
- [Source](https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings)