### PR TITLE
Users can select from preexisting location or create a new location

### DIFF
--- a/app/controllers/universities_controller.rb
+++ b/app/controllers/universities_controller.rb
@@ -90,5 +90,4 @@ class UniversitiesController < ApplicationController
     logged_in_user = User.find_by(Email: session[:email])
     logged_in_user&.is_Admin
   end
-
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,7 +19,8 @@ class User < ApplicationRecord
   validates :Current_Job, presence: true
   validates :firm_type_id, presence: true
 
-  validates :Linkedin_Profile, presence: true, format: { with: /\A(N\/A|https?:\/\/(?:www\.)?linkedin\.com\/.*)\z/, message: "must be 'N/A' or a valid LinkedIn URL" }
+  validates :Linkedin_Profile, presence: true,
+                               format: { with: %r{\A(N/A|https?://(?:www\.)?linkedin\.com/.*)\z}, message: "must be 'N/A' or a valid LinkedIn URL" }
 
   validates :practice_areas, presence: true
   validates :is_Admin, presence: { allow_blank: true }

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -48,7 +48,7 @@
   <div class="px-3 mb-4" id="new_location_fields">
     <div class="mb-4">
       <%= form.label :Select_Location, "Select Existing Location", class: "#{label_class}" %>
-      <%= form.collection_select :location_id, Location.order(:city), :id, :location_string, include_blank: true, class: "flex-1" %>
+      <%= form.collection_select :location_id, Location.order(:city), :id, :location_string, include_blank: true, class: "flex-1", onchange: "populateLocationFields(this)" %>
     </div>
     <p class="text-sm text-gray-600">Or create a new location:</p>
     <div class="md:flex items-center mb-4">
@@ -68,6 +68,25 @@
       <% end %>
     </div>
   </div>
+
+  <script>
+    function populateLocationFields(selectElement) {
+      var selectedOption = selectElement.options[selectElement.selectedIndex];
+      var countryField = document.querySelector("#user_location_attributes_country");
+      var stateField = document.querySelector("#user_location_attributes_state");
+      var cityField = document.querySelector("#user_location_attributes_city");
+
+      if (selectedOption.value !== "") {
+        countryField.value = selectedOption.dataset.country;
+        stateField.value = selectedOption.dataset.state;
+        cityField.value = selectedOption.dataset.city;
+      } else {
+        countryField.value = "";
+        stateField.value = "";
+        cityField.value = "";
+      }
+    }
+  </script>
   
   <hr>
 
@@ -105,28 +124,4 @@
     <%= form.submit "Save", class: "shadow bg-gray-800 hover:bg-gray-400 focus:shadow-outline focus:outline-none text-white font-bold py-2 px-4 rounded" %>
   </div>
 
-  <!--script>
-    // Wait for the DOM to be fully loaded
-    document.addEventListener("DOMContentLoaded", function() {
-      // Get the select dropdown and the div for the new location fields
-      var locationSelect = document.querySelector('#user_location_id');
-      var newLocationFields = document.querySelector('#new_location_fields');
-
-      // Define a function to toggle the display of the new location fields
-      var toggleNewLocationFields = function() {
-        // Check if the dropdown's value is empty (meaning 'choose a location' is selected)
-        if(locationSelect.value) {
-          newLocationFields.style.display = 'none';
-        } else {
-          newLocationFields.style.display = 'block';
-        }
-      };
-
-      // Add an event listener to the select dropdown to toggle the new location fields
-      locationSelect.addEventListener('change', toggleNewLocationFields);
-
-      // Call the toggle function initially in case the select is already set to an empty value
-      toggleNewLocationFields();
-    });
-  </script -->
 <% end %>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -48,46 +48,29 @@
   <div class="px-3 mb-4" id="new_location_fields">
     <div class="mb-4">
       <%= form.label :Select_Location, "Select Existing Location", class: "#{label_class}" %>
-      <%= form.collection_select :location_id, Location.order(:city), :id, :location_string, include_blank: true, class: "flex-1", onchange: "populateLocationFields(this)" %>
+      <%= form.collection_select :location_id, Location.order(:city), :id, :location_string, include_blank: "Create new location", id: "location_select", class: "flex-1" %>
     </div>
-    <p class="text-sm text-gray-600">Or create a new location:</p>
-    <div class="md:flex items-center mb-4">
-      <%= form.fields_for :location, Location.new do |location_form| %>
-        <div class="md:w-1/2 mb-4 md:mb-0">
-          <%= form.label :Country, "Country", class: "#{label_class} md:w-1/3" %>
-          <%= location_form.text_field :country, class: text_field_class %>
-        </div>
-        <div class="md:w-1/2 px-3">
-          <%= form.label :State, "State", class: "#{label_class} md:w-1/3" %>
-          <%= location_form.text_field :state, class: text_field_class %>
-        </div>
-        <div class="md:w-1/2 px-3">
-          <%= form.label :City, "City", class: "#{label_class} md:w-1/3" %>
-          <%= location_form.text_field :city, class: text_field_class %>
-        </div>
-      <% end %>
+    <div id="new_location_form">
+      <p class="text-sm text-gray-600">Or create a new location:</p>
+      <div class="md:flex items-center mb-4">
+        <%= form.fields_for :location, Location.new do |location_form| %>
+          <div class="md:w-1/2 mb-4 md:mb-0">
+            <%= form.label :Country, "Country", class: "#{label_class} md:w-1/3" %>
+            <%= location_form.text_field :country, class: text_field_class %>
+          </div>
+          <div class="md:w-1/2 px-3">
+            <%= form.label :State, "State", class: "#{label_class} md:w-1/3" %>
+            <%= location_form.text_field :state, class: text_field_class %>
+          </div>
+          <div class="md:w-1/2 px-3">
+            <%= form.label :City, "City", class: "#{label_class} md:w-1/3" %>
+            <%= location_form.text_field :city, class: text_field_class %>
+          </div>
+        <% end %>
+      </div>
     </div>
   </div>
-
-  <script>
-    function populateLocationFields(selectElement) {
-      var selectedOption = selectElement.options[selectElement.selectedIndex];
-      var countryField = document.querySelector("#user_location_attributes_country");
-      var stateField = document.querySelector("#user_location_attributes_state");
-      var cityField = document.querySelector("#user_location_attributes_city");
-
-      if (selectedOption.value !== "") {
-        countryField.value = selectedOption.dataset.country;
-        stateField.value = selectedOption.dataset.state;
-        cityField.value = selectedOption.dataset.city;
-      } else {
-        countryField.value = "";
-        stateField.value = "";
-        cityField.value = "";
-      }
-    }
-  </script>
-  
+    
   <hr>
 
   <div class="md:flex md:items-center mb-4">

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -5,7 +5,9 @@
 <br>
 
 <div>
-  <%= link_to "Delete this user", delete_user_path(@user)%>
+  <% if @user.persisted? %>
+    <%= link_to "Delete this user", delete_user_path(@user) %>
+  <% end %>
 </div>
 
 <!--div>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -73,18 +73,18 @@ na_firm_type = FirmType.find_by!(firm_type: 'N/A')
 # temp values, should be replaced by BLSA gmail account
 users = [
   {
-  First_Name: 'Admin Sam',
-  Last_Name: 'Cole',
-  Middle_Name: 'David',
-  Profile_Picture: 'url.com',
-  Email: 'samdcole48@gmail.com',
-  Phone_Number: '123-456-7890',
-  Current_Job: 'Test Admin',
-  location_id: na_location.id,
-  firm_type_id: na_firm_type.id,
-  practice_areas: [na_practice_area],
-  Linkedin_Profile: 'https://www.linkedin.com/in/samuel-cole-91100a1a9/',
-  is_Admin: true
+    First_Name: 'Admin Sam',
+    Last_Name: 'Cole',
+    Middle_Name: 'David',
+    Profile_Picture: 'url.com',
+    Email: 'samdcole48@gmail.com',
+    Phone_Number: '123-456-7890',
+    Current_Job: 'Test Admin',
+    location_id: na_location.id,
+    firm_type_id: na_firm_type.id,
+    practice_areas: [na_practice_area],
+    Linkedin_Profile: 'https://www.linkedin.com/in/samuel-cole-91100a1a9/',
+    is_Admin: true
   }
 ]
 

--- a/spec/system/creating_users_spec.rb
+++ b/spec/system/creating_users_spec.rb
@@ -9,10 +9,15 @@ RSpec.describe('Creating Users', type: :system) do
     Rails.application.env_config['devise.mapping'] = Devise.mappings[:user]
     Rails.application.env_config['omniauth.auth'] = OmniAuth.config.mock_auth[:google_oauth2]
     Rails.application.load_seed
+    @location_id = Location.create!(
+      country: 'USA',
+      state: 'California',
+      city: 'San Jose'
+    )
     login
   end
 
-  it '(Sunny Day) saves and displays the resulting user' do
+  it '(Sunny Day) saves and displays the resulting user using a new location' do
     # login automatically creates a user, so we need to destroy user
     # set_user
     destroy_user
@@ -25,6 +30,7 @@ RSpec.describe('Creating Users', type: :system) do
     fill_in 'Phone number', with: '123-456-7890'
     fill_in 'Current job', with: 'Software Engineer'
     select 'Government', from: 'user_firm_type_id'
+    select 'Create new location', from: 'user_location_id'
     fill_in 'user_location_attributes_country', with: 'USA'
     fill_in 'user_location_attributes_state', with: 'New York'
     fill_in 'user_location_attributes_city', with: 'New York'
@@ -54,6 +60,7 @@ RSpec.describe('Creating Users', type: :system) do
 
   it '(Rainy Day) does not save the user if the First Name is missing' do
     visit new_user_path
+    select @location_id.city, from: 'user_location_id'
     fill_in 'First name', with: ''
     click_on 'Save'
     expect(page).to(have_content("First name can't be blank"))
@@ -61,6 +68,7 @@ RSpec.describe('Creating Users', type: :system) do
 
   it '(Rainy Day) does not save the user if the Last Name is missing' do
     visit new_user_path
+    select @location_id.city, from: 'user_location_id'
     fill_in 'Last name', with: ''
     click_on 'Save'
     expect(page).to(have_content("Last name can't be blank"))
@@ -68,6 +76,7 @@ RSpec.describe('Creating Users', type: :system) do
 
   it '(Rainy Day) does not save the user if the Middle Name is missing' do
     visit new_user_path
+    select @location_id.city, from: 'user_location_id'
     fill_in 'Middle name', with: ''
     click_on 'Save'
     expect(page).to(have_content("Middle name can't be blank"))
@@ -75,21 +84,15 @@ RSpec.describe('Creating Users', type: :system) do
 
   it '(Rainy Day) does not save the user if the Profile Picture is missing' do
     visit new_user_path
+    select @location_id.city, from: 'user_location_id'
     fill_in 'Profile picture', with: ''
     click_on 'Save'
     expect(page).to(have_content("Profile picture can't be blank"))
   end
 
-  # this test is removed since the user no longer inputs the email address
-  # it '(Rainy Day) does not save the user if the Email is missing' do
-  #   visit new_user_path
-  #   fill_in 'Email', with: ''
-  #   click_on 'Save'
-  #   expect(page).to(have_content("Email can't be blank"))
-  # end
-
   it '(Rainy Day) does not save the user if the Phone Number is missing' do
     visit new_user_path
+    select @location_id.city, from: 'user_location_id'
     fill_in 'Phone number', with: ''
     click_on 'Save'
     expect(page).to(have_content("Phone number can't be blank"))
@@ -97,6 +100,7 @@ RSpec.describe('Creating Users', type: :system) do
 
   it '(Rainy Day) does not save the user if the Current Job is missing' do
     visit new_user_path
+    select @location_id.city, from: 'user_location_id'
     fill_in 'Current job', with: ''
     click_on 'Save'
     expect(page).to(have_content("Current job can't be blank"))
@@ -112,6 +116,7 @@ RSpec.describe('Creating Users', type: :system) do
 
   it '(Rainy Day) does not save the user if the Linkedin Profile is missing' do
     visit new_user_path
+    select @location_id.city, from: 'user_location_id'
     fill_in 'Linkedin profile', with: ''
     click_on 'Save'
     expect(page).to(have_content("Linkedin profile can't be blank"))
@@ -119,6 +124,7 @@ RSpec.describe('Creating Users', type: :system) do
 
   it '(Rainy Day) does not save the user if the Linkedin Profile link is not to linkedin' do
     visit new_user_path
+    select @location_id.city, from: 'user_location_id'
     fill_in 'Linkedin profile', with: 'https://www.myspace.com/john-doe'
     click_on 'Save'
     expect(page).to(have_content("Linkedin profile must be 'N/A' or a valid LinkedIn URL"))
@@ -126,7 +132,35 @@ RSpec.describe('Creating Users', type: :system) do
 
   it '(Rainy Day) does not save the user if the Practice Area is missing' do
     visit new_user_path
+    select @location_id.city, from: 'user_location_id'
     click_on 'Save'
     expect(page).to(have_content("Practice areas can't be blank"))
+  end
+
+  it '(Rainy Day) does not save if user leaves country field blank' do
+    visit new_user_path
+    select 'Create new location', from: 'user_location_id'
+    fill_in 'user_location_attributes_country', with: ''
+
+    click_on 'Save'
+    expect(page).to(have_content('Country can\'t be blank'))
+  end
+
+  it '(Rainy Day) does not save if user leaves state field blank' do
+    visit new_user_path
+    select 'Create new location', from: 'user_location_id'
+    fill_in 'user_location_attributes_state', with: ''
+
+    click_on 'Save'
+    expect(page).to(have_content('State can\'t be blank'))
+  end
+
+  it '(Rainy Day) does not save if users leaves city field blank' do
+    visit new_user_path
+    select 'Create new location', from: 'user_location_id'
+    fill_in 'user_location_attributes_city', with: ''
+
+    click_on 'Save'
+    expect(page).to(have_content('City can\'t be blank'))
   end
 end

--- a/spec/system/deleting_universities_spec.rb
+++ b/spec/system/deleting_universities_spec.rb
@@ -32,6 +32,6 @@ RSpec.describe('Deleting Universities', type: :system) do
 
     visit university_path(@university.id)
 
-    expect(page).not_to have_button("Delete University")
+    expect(page).not_to(have_button('Delete University'))
   end
 end

--- a/spec/system/deleting_users_spec.rb
+++ b/spec/system/deleting_users_spec.rb
@@ -52,7 +52,6 @@ RSpec.describe('Deleting Users', type: :system) do
   end
 
   it '(Sunny Day) Admin user can delete a user that is not themself' do
-
     visit delete_user_path(@user2.id)
 
     click_on 'Destroy this user'

--- a/spec/system/updating_users_spec.rb
+++ b/spec/system/updating_users_spec.rb
@@ -65,11 +65,6 @@ RSpec.describe('Updating Users', type: :system) do
   it '(Sunny Day) Update First Name' do
     visit edit_user_path(@user.id)
 
-    # HARDCODED TESTS, REMOVE LATER AND FIX
-    fill_in 'user_location_attributes_country', with: 'USA'
-    fill_in 'user_location_attributes_state', with: 'New York'
-    fill_in 'user_location_attributes_city', with: 'New York'
-
     fill_in 'user_First_Name', with: 'Jane'
 
     click_on 'Save'
@@ -89,11 +84,6 @@ RSpec.describe('Updating Users', type: :system) do
 
   it '(Sunny Day) Update Last Name' do
     visit edit_user_path(@user.id)
-
-    # HARDCODED TESTS, REMOVE LATER AND FIX
-    fill_in 'user_location_attributes_country', with: 'USA'
-    fill_in 'user_location_attributes_state', with: 'New York'
-    fill_in 'user_location_attributes_city', with: 'New York'
 
     fill_in 'user_Last_Name', with: 'Smith'
 
@@ -115,11 +105,6 @@ RSpec.describe('Updating Users', type: :system) do
   it '(Sunny Day) Update Middle Name' do
     visit edit_user_path(@user.id)
 
-    # HARDCODED TESTS, REMOVE LATER AND FIX
-    fill_in 'user_location_attributes_country', with: 'USA'
-    fill_in 'user_location_attributes_state', with: 'New York'
-    fill_in 'user_location_attributes_city', with: 'New York'
-
     fill_in 'user_Middle_Name', with: 'L'
 
     click_on 'Save'
@@ -140,11 +125,6 @@ RSpec.describe('Updating Users', type: :system) do
   it '(Sunny Day) Update Profile Picture' do
     visit edit_user_path(@user.id)
 
-    # HARDCODED TESTS, REMOVE LATER AND FIX
-    fill_in 'user_location_attributes_country', with: 'USA'
-    fill_in 'user_location_attributes_state', with: 'New York'
-    fill_in 'user_location_attributes_city', with: 'New York'
-
     fill_in 'user_Profile_Picture', with: 'https://www.facebook.com'
 
     click_on 'Save'
@@ -162,34 +142,8 @@ RSpec.describe('Updating Users', type: :system) do
     expect(page).to(have_content("Profile picture can't be blank"))
   end
 
-  # these tests should be removed since the user no longer enters their own email
-  # it '(Sunny Day) Update Email' do
-  #   visit edit_user_path(@user.id)
-
-  #   fill_in 'user_Email', with: 'JaneSmith@gmail.com'
-
-  #   click_on 'Save'
-
-  #   expect(page).to(have_content('JaneSmith@gmail.com'))
-  # end
-
-  # it '(Rainy Day) Empty Email' do
-  #   visit edit_user_path(@user.id)
-
-  #   fill_in 'user_Email', with: ''
-
-  #   click_on 'Save'
-
-  #   expect(page).to(have_content("Email can't be blank"))
-  # end
-
   it '(Sunny Day) Update Phone Number' do
     visit edit_user_path(@user.id)
-
-    # HARDCODED TESTS, REMOVE LATER AND FIX
-    fill_in 'user_location_attributes_country', with: 'USA'
-    fill_in 'user_location_attributes_state', with: 'New York'
-    fill_in 'user_location_attributes_city', with: 'New York'
 
     fill_in 'user_Phone_Number', with: '555-555-5555'
 
@@ -210,11 +164,6 @@ RSpec.describe('Updating Users', type: :system) do
 
   it '(Sunny Day) Update Current Job' do
     visit edit_user_path(@user.id)
-
-    # HARDCODED TESTS, REMOVE LATER AND FIX
-    fill_in 'user_location_attributes_country', with: 'USA'
-    fill_in 'user_location_attributes_state', with: 'New York'
-    fill_in 'user_location_attributes_city', with: 'New York'
 
     fill_in 'user_Current_Job', with: 'Lawyer'
 
@@ -239,11 +188,6 @@ RSpec.describe('Updating Users', type: :system) do
     )
     visit edit_user_path(@user.id)
 
-    # HARDCODED TESTS, REMOVE LATER AND FIX
-    fill_in 'user_location_attributes_country', with: 'USA'
-    fill_in 'user_location_attributes_state', with: 'New York'
-    fill_in 'user_location_attributes_city', with: 'New York'
-
     select @firm_type_new.firm_type, from: 'user_firm_type_id'
 
     click_on 'Save'
@@ -251,35 +195,77 @@ RSpec.describe('Updating Users', type: :system) do
     expect(page).to(have_content(@firm_type_new.firm_type))
   end
 
-  # not sure how to add rainy day case since user only has the options given to them
+  it '(Sunny Day) Update Location to an existing location' do
+    @new_location_id = Location.create!(
+      country: 'USA',
+      state: 'California',
+      city: 'San Jose'
+    )
+    visit edit_user_path(@user.id)
+    select @new_location_id.city, from: 'user_location_id'
 
-  # it '(Sunny Day) Update Location' do
-  #   visit edit_user_path(@user.id)
+    click_on 'Save'
+    expect(page).to(have_content(@new_location_id.location_string))
+  end
 
-  #   fill_in 'user_Location', with: 'Los Angeles'
+  it '(Sunny Day) Update Location to a new location' do
+    visit edit_user_path(@user.id)
 
-  #   click_on 'Save'
+    select 'Create new location', from: 'user_location_id'
+    fill_in 'user_location_attributes_country', with: 'USA'
+    fill_in 'user_location_attributes_state', with: 'California'
+    fill_in 'user_location_attributes_city', with: 'San Jose'
 
-  #   expect(page).to(have_content('Los Angeles'))
-  # end
+    click_on 'Save'
+    expect(page).to(have_content('San Jose, California, USA'))
+  end
 
-  # it '(Rainy Day) Empty Location' do
-  #   visit edit_user_path(@user.id)
+  it '(Rainy Day) Update Location select existing location, and fill out new location areas' do
+    @new_location_id = Location.create!(
+      country: 'USA',
+      state: 'California',
+      city: 'San Jose'
+    )
+    visit edit_user_path(@user.id)
+    select @new_location_id.city, from: 'user_location_id'
 
-  #   fill_in 'user_Location', with: ''
+    fill_in 'user_location_attributes_country', with: 'USA'
+    fill_in 'user_location_attributes_state', with: 'California'
+    fill_in 'user_location_attributes_city', with: 'San Jose'
 
-  #   click_on 'Save'
+    click_on 'Save'
+    expect(page).to(have_content(@new_location_id.location_string))
+  end
 
-  #   expect(page).to(have_content("Location can't be blank"))
-  # end
+  it '(Rainy Day) Update Location to a new location, but leave country field blank' do
+    visit edit_user_path(@user.id)
+    select 'Create new location', from: 'user_location_id'
+    fill_in 'user_location_attributes_country', with: ''
+
+    click_on 'Save'
+    expect(page).to(have_content('Country can\'t be blank'))
+  end
+
+  it '(Rainy Day) Update Location to a new location, but leave state field blank' do
+    visit edit_user_path(@user.id)
+    select 'Create new location', from: 'user_location_id'
+    fill_in 'user_location_attributes_state', with: ''
+
+    click_on 'Save'
+    expect(page).to(have_content('State can\'t be blank'))
+  end
+
+  it '(Rainy Day) Update Location to a new location, but leave city field blank' do
+    visit edit_user_path(@user.id)
+    select 'Create new location', from: 'user_location_id'
+    fill_in 'user_location_attributes_city', with: ''
+
+    click_on 'Save'
+    expect(page).to(have_content('City can\'t be blank'))
+  end
 
   it '(Sunny Day) Update Linkedin Profile to valid url' do
     visit edit_user_path(@user.id)
-
-    # HARDCODED TESTS, REMOVE LATER AND FIX
-    fill_in 'user_location_attributes_country', with: 'USA'
-    fill_in 'user_location_attributes_state', with: 'New York'
-    fill_in 'user_location_attributes_city', with: 'New York'
 
     fill_in 'user_Linkedin_Profile', with: 'https://www.linkedin.com/in/john-doe2'
 
@@ -290,11 +276,6 @@ RSpec.describe('Updating Users', type: :system) do
 
   it '(Sunny Day) Update Linkedin Profile to N/A' do
     visit edit_user_path(@user.id)
-
-    # HARDCODED TESTS, REMOVE LATER AND FIX
-    fill_in 'user_location_attributes_country', with: 'USA'
-    fill_in 'user_location_attributes_state', with: 'New York'
-    fill_in 'user_location_attributes_city', with: 'New York'
 
     fill_in 'user_Linkedin_Profile', with: 'N/A'
 
@@ -328,11 +309,6 @@ RSpec.describe('Updating Users', type: :system) do
 
     visit edit_user_path(@user2.id)
 
-    # HARDCODED TESTS, REMOVE LATER AND FIX
-    fill_in 'user_location_attributes_country', with: 'USA'
-    fill_in 'user_location_attributes_state', with: 'New York'
-    fill_in 'user_location_attributes_city', with: 'New York'
-
     fill_in 'user_First_Name', with: 'Jane'
 
     click_on 'Save'
@@ -341,13 +317,7 @@ RSpec.describe('Updating Users', type: :system) do
   end
 
   it '(Sunny Day) Admin users can edit a profile that is not theirs' do
-
     visit edit_user_path(@user2.id)
-
-    # HARDCODED TESTS, REMOVE LATER AND FIX
-    fill_in 'user_location_attributes_country', with: 'USA'
-    fill_in 'user_location_attributes_state', with: 'New York'
-    fill_in 'user_location_attributes_city', with: 'New York'
 
     fill_in 'user_First_Name', with: 'Jane'
 

--- a/spec/views/universities/show.html.tailwindcss_spec.rb
+++ b/spec/views/universities/show.html.tailwindcss_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe('universities/show', type: :view) do
     def view.current_user_is_admin?
       false
     end
-
   end
 
   it 'renders attributes in <p>' do


### PR DESCRIPTION
Made it so location drop-down choices will auto-populate country, state, and city text fields without creating duplicate entries during user creation.