### PR TITLE
BLSA account removed from user search, View admins page created and only accessible by admins

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -31,7 +31,7 @@ class UsersController < ApplicationController
                when 'class_year'
                  search_year = Integer(search_term, 10)
                  @users = User.joins(:education_infos)
-                              .select("users.*, MIN(ABS(education_infos.\"Grad_Year\" - #{search_year})) AS year_diff")
+                              .select("users.*, MIN(ABS(education_infos.\"Grad_Year\" - ?)) AS year_diff", search_year)
                               .group('users.id')
                               .order('year_diff')
                when 'practice_area'

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -188,6 +188,27 @@ class UsersController < ApplicationController
       end
       return
     end
+
+    @sort_by = params[:sort_by] || 'name'
+    @sort_direction = params[:sort_direction] || 'asc'
+    @users = User.where(is_Admin: true)
+
+    if params[:search].present?
+      search_term = params[:search].downcase
+      @users = User.where(
+        "LOWER(CONCAT(\"First_Name\", ' ', \"Last_Name\")) LIKE :search OR
+        LOWER(CONCAT(\"First_Name\", ' ', \"Middle_Name\")) LIKE :search OR
+        LOWER(\"First_Name\") LIKE :search OR
+        LOWER(\"Last_Name\") LIKE :search OR
+        LOWER(\"Middle_Name\") LIKE :search",
+        search: "%#{search_term}%"
+      )
+    end
+
+    case @sort_by
+    when 'name'
+      @users = @users.order("\"First_Name\" #{@sort_direction}, \"Last_Name\" #{@sort_direction}")
+    end
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -179,6 +179,17 @@ class UsersController < ApplicationController
     end
   end
 
+  # GET /users/view_admins
+  def view_admins
+    if !current_user_is_admin?
+      respond_to do |format|
+        format.html { redirect_to(root_path, alert: 'Only admins can view this page.') }
+        format.json { render(json: { error: 'Unauthorized' }, status: :unauthorized) }
+      end
+      return
+    end
+  end
+
   private
 
   # Use callbacks to share common setup or constraints between actions.

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -28,12 +28,12 @@ class UsersController < ApplicationController
                    'LOWER(locations.city) LIKE :search OR LOWER(locations.state) LIKE :search OR LOWER(locations.country) LIKE :search',
                    search: "%#{search_term}%"
                  )
-                when 'class_year'
-                  search_year = search_term.to_i
-                  @users = User.joins(:education_infos)
-                               .select("users.*, MIN(ABS(education_infos.\"Grad_Year\" - #{search_year})) AS year_diff")
-                               .group('users.id')
-                               .order('year_diff')
+               when 'class_year'
+                 search_year = Integer(search_term, 10)
+                 @users = User.joins(:education_infos)
+                              .select("users.*, MIN(ABS(education_infos.\"Grad_Year\" - #{search_year})) AS year_diff")
+                              .group('users.id')
+                              .order('year_diff')
                when 'practice_area'
                  User.joins(:practice_areas).where('LOWER(practice_areas.practice_area) LIKE ?', "%#{search_term}%")
                else
@@ -181,7 +181,7 @@ class UsersController < ApplicationController
 
   # GET /users/view_admins
   def view_admins
-    if !current_user_is_admin?
+    unless current_user_is_admin?
       respond_to do |format|
         format.html { redirect_to(root_path, alert: 'Only admins can view this page.') }
         format.json { render(json: { error: 'Unauthorized' }, status: :unauthorized) }

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,4 +1,8 @@
 # frozen_string_literal: true
 
 module UsersHelper
+  def current_user_is_admin?
+    logged_in_user = User.find_by(Email: session[:email])
+    logged_in_user&.is_Admin
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,6 +31,9 @@
             <li><%= link_to "Users", users_path, class: "text-white hover:text-gray-300" %></li>
             <li><%= link_to "Education Info", education_infos_path, class: "text-white hover:text-gray-300" %></li>
             <li><%= link_to "Universities", universities_path, class: "text-white hover:text-gray-300" %></li>
+            <% if current_user_is_admin? %>
+              <li><%= link_to "Admins", view_admins_users_path, class: "text-white hover:text-gray-300" %></li>
+            <% end %>
             <% if current_user %>
               <li><%= link_to "Profile", edit_user_path(current_user), class: "text-white hover:text-gray-300" %></li>
             <% else %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -68,6 +68,7 @@
      </thead>
     <tbody>
       <% @users.each do |user| %>
+      <% next if user.Email == 'blsa.tamu@gmail.com' %> <!-- Skip the BLSA account -->
         <tr class="hover:bg-gray-100 cursor-pointer" onclick="window.location='<%= user_path(user) %>'">
           <td class="text-center px-5 py-5 border-b border-gray-200 bg-white text-sm">
             <!-- User name and avatar here -->

--- a/app/views/users/view_admins.html.erb
+++ b/app/views/users/view_admins.html.erb
@@ -1,0 +1,1 @@
+<h1>View admins</h1>

--- a/app/views/users/view_admins.html.erb
+++ b/app/views/users/view_admins.html.erb
@@ -1,1 +1,100 @@
-<h1>View admins</h1>
+<div class="flex justify-center my-4">
+    <%= form_with(url: view_admins_users_path, method: :get, local: true, class: "w-1/2") do |form| %>
+        <div class="flex items-center">
+            <div class="relative flex-grow">
+                <%= form.text_field :search, value: params[:search], placeholder: "Search admins...", class: "w-full pl-4 pr-48 py-2 rounded-md border border-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+                <div class="absolute inset-y-0 right-0 flex items-center">
+                    <%= form.select :filter, options_for_select([['Name', 'name']], params[:filter]), { prompt: 'Filter by' }, class: "w-48 py-2 rounded-r-md border border-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+                </div>
+            </div>
+            <%= form.submit "Search", class: "ml-2 px-4 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+        </div>
+    <% end %>
+</div>
+
+<div class="overflow-x-auto">
+    <table class="min-w-full leading-normal">
+        <thead>
+            <tr>
+                <th class="text-center px-5 py-3 border-b-2 border-gray-200 bg-gray-100 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">
+                <%= link_to users_path(sort_by: 'name', sort_direction: @sort_direction == 'asc' ? 'desc' : 'asc', search: params[:search], filter: params[:filter]), class: 'text-gray-600 hover:text-gray-800' do %>
+                Name
+                <% if @sort_by == 'name' %>
+                    <% if @sort_direction == 'asc' %>
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="ml-1 inline-block w-4 h-4">
+                        <path fill-rule="evenodd" d="M5.293 9.707a1 1 0 010-1.414l4-4a1 1 0 011.414 0l4 4a1 1 0 01-1.414 1.414L10 6.414l-3.293 3.293a1 1 0 01-1.414 0z" clip-rule="evenodd" />
+                    </svg>
+                    <% else %>
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="ml-1 inline-block w-4 h-4">
+                        <path fill-rule="evenodd" d="M14.707 10.293a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 111.414-1.414L10 13.586l3.293-3.293a1 1 0 011.414 0z" clip-rule="evenodd" />
+                    </svg>
+                    <% end %>
+                <% end %>
+                <% end %>
+                </th>
+                <th class="text-center px-5 py-3 border-b-2 border-gray-200 bg-gray-100 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">
+                <%= link_to users_path(sort_by: 'current_job', sort_direction: @sort_direction == 'asc' ? 'desc' : 'asc', search: params[:search], filter: params[:filter]), class: 'text-gray-600 hover:text-gray-800' do %>
+                    Current Job
+                    <% if @sort_by == 'current_job' %>
+                    <% if @sort_direction == 'asc' %>
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="ml-1 inline-block w-4 h-4">
+                        <path fill-rule="evenodd" d="M5.293 9.707a1 1 0 010-1.414l4-4a1 1 0 011.414 0l4 4a1 1 0 01-1.414 1.414L10 6.414l-3.293 3.293a1 1 0 01-1.414 0z" clip-rule="evenodd" />
+                        </svg>
+                    <% else %>
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="ml-1 inline-block w-4 h-4">
+                        <path fill-rule="evenodd" d="M14.707 10.293a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 111.414-1.414L10 13.586l3.293-3.293a1 1 0 011.414 0z" clip-rule="evenodd" />
+                        </svg>
+                    <% end %>
+                    <% end %>
+                <% end %>
+                </th>
+                <th class="text-center px-5 py-3 border-b-2 border-gray-200 bg-gray-100 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">
+                <%= link_to users_path(sort_by: 'practice_areas', sort_direction: @sort_direction == 'asc' ? 'desc' : 'asc', search: params[:search], filter: params[:filter]), class: 'text-gray-600 hover:text-gray-800' do %>
+                    Practice Areas
+                    <% if @sort_by == 'practice_areas' %>
+                    <% if @sort_direction == 'asc' %>
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="ml-1 inline-block w-4 h-4">
+                        <path fill-rule="evenodd" d="M5.293 9.707a1 1 0 010-1.414l4-4a1 1 0 011.414 0l4 4a1 1 0 01-1.414 1.414L10 6.414l-3.293 3.293a1 1 0 01-1.414 0z" clip-rule="evenodd" />
+                        </svg>
+                    <% else %>
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="ml-1 inline-block w-4 h-4">
+                        <path fill-rule="evenodd" d="M14.707 10.293a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 111.414-1.414L10 13.586l3.293-3.293a1 1 0 011.414 0z" clip-rule="evenodd" />
+                        </svg>
+                    <% end %>
+                    <% end %>
+                <% end %>
+                </th>
+            </tr>
+        </thead>
+        <tbody>
+        <% @users.each do |user| %>
+            <% next if !user.is_Admin %> <!-- Only display admins -->
+            <tr class="hover:bg-gray-100 cursor-pointer" onclick="window.location='<%= user_path(user) %>'">
+            <td class="text-center px-5 py-5 border-b border-gray-200 bg-white text-sm">
+                <!-- User name here -->
+                <%= "#{user.First_Name} #{user.Last_Name}" %>
+            </td>
+            <td class="text-center px-5 py-5 border-b border-gray-200 bg-white text-sm">
+                <!-- User current job here -->
+                <%= user.Current_Job %>
+            </td>
+            <td class="text-center px-5 py-5 border-b border-gray-200 bg-white text-sm">
+                <!-- User practice areas here; joined if present -->
+                <%= user.practice_areas.map(&:practice_area).join(', ') %>
+            </td>
+            </tr>
+        <% end %>
+        </tbody>
+    </table>
+</div>
+
+<script>
+    document.addEventListener('DOMContentLoaded', () => {
+        const rows = document.querySelectorAll('tr[data-href]');
+        rows.forEach(row => {
+            row.addEventListener('click', () => {
+                window.location.href = row.dataset.href;
+            });
+        });
+    });
+</script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,9 @@ Rails.application.routes.draw do
     member do
       get :delete
     end
+    collection do
+      get :view_admins
+    end
   end
 
   resources :universities

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -71,6 +71,7 @@ na_practice_area = PracticeArea.find_by!(practice_area: 'N/A')
 na_firm_type = FirmType.find_by!(firm_type: 'N/A')
 
 # temp values, should be replaced by BLSA gmail account
+# make blsa email account first name BLSA last name Admin so that it looks better in admin search
 users = [
   {
     First_Name: 'Admin Sam',

--- a/spec/views/users/index.html.erb_spec.rb
+++ b/spec/views/users/index.html.erb_spec.rb
@@ -1,22 +1,24 @@
+# frozen_string_literal: true
+
 # spec/views/users/index.html.erb_spec.rb
 
 require 'rails_helper'
 
 RSpec.describe('users/index', type: :view) do
   def create_practice_area(practice_area)
-    PracticeArea.find_or_create_by(practice_area: practice_area)
+    PracticeArea.find_or_create_by!(practice_area: practice_area)
   end
 
   def create_firm_type(firm_type)
-    FirmType.find_or_create_by(firm_type: firm_type)
+    FirmType.find_or_create_by!(firm_type: firm_type)
   end
 
   def create_location(country, state, city)
-    Location.find_or_create_by(country: country, state: state, city: city)
+    Location.find_or_create_by!(country: country, state: state, city: city)
   end
 
   def create_university(name)
-    University.find_or_create_by(University: name)
+    University.find_or_create_by!(University: name)
   end
 
   def create_user(email:, ft:, pa:, country:, state:, city:, university_name:, semester:, grad_year:, degree_type:)


### PR DESCRIPTION
Makes most since for Hayden to review this since he wrote the search functionality that I used (basically just copied)

Acceptance Criteria:
* Admins (and only admins) have access to a page that shows all users where “is admin” is true. Page should feel identical to users page, allowing them to click on, view, and edit these accounts

*NOT LISTED IN JIRA* 
* BLSA gmail admin account should not be listed in users search
* view admins page should only; be viewable by admins